### PR TITLE
🐛 Fix: hashtag validation error

### DIFF
--- a/characters/serializers.py
+++ b/characters/serializers.py
@@ -8,6 +8,10 @@ class HashtagSerializer(serializers.ModelSerializer):
         model = Hashtag
         fields = ["tag_name"]
 
+        # 시리얼라이져의 중복검사 제외
+        extra_kwargs = {
+            "tag_name": {"validators": []}, 
+        }
 
 # 캐릭터 인트로
 class CharacterIntroSerializer(serializers.Serializer):
@@ -115,27 +119,27 @@ class CharacterSerializer(CharacterBaseSerializer):
 
         character = Character.objects.create(user=user, **validated_data)
 
-        for tag_dict in hashtag_data:
-            tag_name = tag_dict["tag_name"].lstrip("#")
+        for tag in hashtag_data:
+            tag_name = tag["tag_name"].lstrip("#")
             hashtag, created = Hashtag.objects.get_or_create(tag_name=tag_name)
             character.hashtags.add(hashtag)
 
         return character
 
     # 캐릭터 수정시 해시태그
-    def update(self, character_obj, validated_data):
+    def update(self, character, validated_data):
         hashtag_data = validated_data.pop("hashtags", None)
 
-        character_obj = super().update(character_obj, validated_data)
+        character = super().update(character, validated_data)
 
         if hashtag_data is not None:
-            character_obj.hashtags.clear()
-            for tag_dict in hashtag_data:
-                tag_name = tag_dict["tag_name"].lstrip("#")
-                hashtag, _ = Hashtag.objects.get_or_create(tag_name=tag_name)
-                character_obj.hashtags.add(hashtag)
+            character.hashtags.clear()
+            for tag in hashtag_data:
+                tag_name = tag["tag_name"].lstrip("#")
+                hashtag, created = Hashtag.objects.get_or_create(tag_name=tag_name)
+                character.hashtags.add(hashtag)
 
-        return character_obj
+        return character
 
 
 # 다른사람이 캐릭터를 조회할때


### PR DESCRIPTION
모델 unique 중복 검사와 시리얼라이저 중복 검사 충돌 문제 해결

#81 

## 📝 요약(Summary)

- 캐릭터 생성,수정 이미 등록된 해시태그와 중복일경우 오류발생
- 모델에서 unique=True -> 시리얼라이저에서 중복검사로 오류 발생
- 해시태그 시리얼라이저의 검사에서 제외

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
